### PR TITLE
Rewrite `nn.Module` comparison

### DIFF
--- a/hamming-core/Cargo.lock
+++ b/hamming-core/Cargo.lock
@@ -15,6 +15,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +64,7 @@ dependencies = [
  "numpy",
  "pyo3",
  "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -280,6 +312,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/hamming-core/Cargo.toml
+++ b/hamming-core/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["lib", "cdylib"]
 numpy = "0.25.0"
 pyo3 = "0.25.0"
 rand = "0.9.2"
+rayon = "1.11.0"

--- a/hamming-core/src/lib.rs
+++ b/hamming-core/src/lib.rs
@@ -85,5 +85,7 @@ mod hamming_core {
 
         #[pymodule_export]
         use crate::python::generic::compare_array_list_bitwise_f32;
+        #[pymodule_export]
+        use crate::python::generic::compare_array_list_bitwise_u16;
     }
 }

--- a/hamming-core/src/lib.rs
+++ b/hamming-core/src/lib.rs
@@ -71,7 +71,7 @@ mod hamming_core {
         use crate::python::u256::encode_u16;
     }
 
-    /// Fault injection for generic arrays.
+    /// Functions for generic arrays & lists of arrays.
     #[pymodule]
     mod generic {
         #[pymodule_export]
@@ -82,5 +82,8 @@ mod hamming_core {
         use crate::python::generic::u16_array_fi;
         #[pymodule_export]
         use crate::python::generic::u16_array_list_fi;
+
+        #[pymodule_export]
+        use crate::python::generic::compare_array_list_bitwise_f32;
     }
 }

--- a/hamming-core/src/python/generic.rs
+++ b/hamming-core/src/python/generic.rs
@@ -116,3 +116,35 @@ pub fn compare_array_list_bitwise_f32<'py>(
 
     Ok(output)
 }
+
+/// Computes bit masks for non-matching bits for all items.
+#[pyfunction]
+pub fn compare_array_list_bitwise_u16<'py>(
+    _py: Python<'py>,
+    a: Vec<InputArr<u16>>,
+    b: Vec<InputArr<u16>>,
+) -> PyResult<Vec<u16>> {
+    let a = a
+        .into_iter()
+        .flat_map(|x| x.as_array().into_iter().copied().collect::<Vec<u16>>())
+        .collect::<Vec<_>>();
+    let b = b
+        .into_iter()
+        .flat_map(|x| x.as_array().into_iter().copied().collect::<Vec<u16>>())
+        .collect::<Vec<_>>();
+
+    if a.len() != b.len() {
+        return Err(PyValueError::new_err(
+            "The number of items in `a` and `b` don't match",
+        ));
+    }
+
+    let output = a
+        .into_par_iter()
+        .zip(b)
+        .map(|(a_item, b_item)| a_item ^ b_item)
+        .filter(|x| *x > 0)
+        .collect::<Vec<u16>>();
+
+    Ok(output)
+}

--- a/hamming-core/src/python/generic.rs
+++ b/hamming-core/src/python/generic.rs
@@ -1,10 +1,10 @@
-//! Fault injection on generic arrays & lists of arrays.
+//! Functions for generic arrays & lists of arrays.
 use crate::{
     python::common::{fi_context_create, prep_input_array, prep_input_array_list},
     BitBuffer,
 };
 use numpy::PyArray1;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 
 use crate::python::common::{FiContext, InputArr, OutputArr};
 
@@ -82,4 +82,45 @@ pub fn u16_array_list_fi<'py>(
             .collect::<Vec<_>>(),
         fi_context_create(num_faults, num_bits),
     ))
+}
+
+/// Computes bit masks for non-matching bits for all items.
+#[pyfunction]
+pub fn compare_array_list_bitwise_f32<'py>(
+    _py: Python<'py>,
+    a: Vec<InputArr<f32>>,
+    b: Vec<InputArr<f32>>,
+) -> PyResult<Vec<u32>> {
+    if a.len() != b.len() {
+        return Err(PyValueError::new_err(
+            "The lengths of `a` and `b` don't match",
+        ));
+    }
+
+    let output = a
+        .into_iter()
+        .zip(b)
+        .map(|(a_inner, b_inner)| -> PyResult<Vec<u32>> {
+            let a_arr = a_inner.as_array();
+            let b_arr = b_inner.as_array();
+
+            if a_arr.len() != b_arr.len() {
+                return Err(PyValueError::new_err(
+                    "`a` and `b` don't contain the same number of items.",
+                ));
+            }
+
+            let mut output: Vec<u32> = Vec::with_capacity(a_arr.len());
+            for (a_item, b_item) in a_arr.iter().zip(b_arr.iter()) {
+                output.push(a_item.to_bits() | b_item.to_bits());
+            }
+
+            Ok(output)
+        })
+        .collect::<PyResult<Vec<Vec<u32>>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<u32>>();
+
+    Ok(output)
 }

--- a/hamming-core/src/python/generic.rs
+++ b/hamming-core/src/python/generic.rs
@@ -85,6 +85,24 @@ pub fn u16_array_list_fi<'py>(
     ))
 }
 
+#[inline]
+fn compare_f32_vecs_bitwise(a: Vec<f32>, b: Vec<f32>) -> Vec<u32> {
+    a.into_par_iter()
+        .zip(b)
+        .map(|(a_item, b_item)| a_item.to_bits() ^ b_item.to_bits())
+        .filter(|x| *x > 0)
+        .collect::<Vec<u32>>()
+}
+
+#[inline]
+fn compare_u16_vecs_bitwise(a: Vec<u16>, b: Vec<u16>) -> Vec<u16> {
+    a.into_par_iter()
+        .zip(b)
+        .map(|(a_item, b_item)| a_item ^ b_item)
+        .filter(|x| *x > 0)
+        .collect::<Vec<u16>>()
+}
+
 /// Computes bit masks for non-matching bits for all items.
 #[pyfunction]
 pub fn compare_array_list_bitwise_f32<'py>(
@@ -107,14 +125,7 @@ pub fn compare_array_list_bitwise_f32<'py>(
         ));
     }
 
-    let output = a
-        .into_par_iter()
-        .zip(b)
-        .map(|(a_item, b_item)| a_item.to_bits() ^ b_item.to_bits())
-        .filter(|x| *x > 0)
-        .collect::<Vec<u32>>();
-
-    Ok(output)
+    Ok(compare_f32_vecs_bitwise(a, b))
 }
 
 /// Computes bit masks for non-matching bits for all items.
@@ -139,12 +150,36 @@ pub fn compare_array_list_bitwise_u16<'py>(
         ));
     }
 
-    let output = a
-        .into_par_iter()
-        .zip(b)
-        .map(|(a_item, b_item)| a_item ^ b_item)
-        .filter(|x| *x > 0)
-        .collect::<Vec<u16>>();
+    Ok(compare_u16_vecs_bitwise(a, b))
+}
 
-    Ok(output)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_f32_vec() {
+        let a = [0b10001101u32, 0b10000001u32]
+            .into_iter()
+            .map(f32::from_bits)
+            .collect();
+        let b = [0b10011100u32, 0b00000001u32]
+            .into_iter()
+            .map(f32::from_bits)
+            .collect();
+
+        let expected = vec![0b00010001u32, 0b10000000u32];
+
+        assert_eq!(compare_f32_vecs_bitwise(a, b), expected);
+    }
+
+    #[test]
+    fn compare_u16_vec() {
+        let a = vec![0b10001101u16, 0b10000001u16];
+        let b = vec![0b10011100u16, 0b00000001u16];
+
+        let expected = vec![0b00010001u16, 0b10000000u16];
+
+        assert_eq!(compare_u16_vecs_bitwise(a, b), expected);
+    }
 }

--- a/hamming-core/src/python/generic.rs
+++ b/hamming-core/src/python/generic.rs
@@ -110,7 +110,8 @@ pub fn compare_array_list_bitwise_f32<'py>(
     let output = a
         .into_par_iter()
         .zip(b)
-        .map(|(a_item, b_item)| a_item.to_bits() | b_item.to_bits())
+        .map(|(a_item, b_item)| a_item.to_bits() ^ b_item.to_bits())
+        .filter(|x| *x > 0)
         .collect::<Vec<u32>>();
 
     Ok(output)


### PR DESCRIPTION
Closes #21 

Ported `nn.Module` comparison code to rust and made it multithreaded. I measured a 370x speedup compared to the previous implementation on Apple M4.